### PR TITLE
Add Gridsome

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,6 +870,7 @@ Besides libraries, there're [Collection on Codepen](http://codepen.io/collection
 ## Generators
 
 * [Gatsby.js](https://github.com/gatsbyjs/gatsby) - React-based static site generator.
+* [Gridsome](https://github.com/gridsome/gridsome) - Vue-powered static site generator.
 
 
 ## SDK


### PR DESCRIPTION
Add Gridsome - a Vue-powered static site generator for building CDN-ready websites for any headless CMS, local files or APIs.